### PR TITLE
Add confirm button for history addition

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,12 +183,17 @@
             color: #888;
         }
 
-        .clear-btn {
-            width: 100%;
+        .button-group {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+
+        .action-btn {
+            flex: 1;
             padding: 15px;
             border: none;
             border-radius: 12px;
-            background: linear-gradient(135deg, #6c757d 0%, #5a6268 100%);
             color: white;
             font-size: 16px;
             font-weight: 600;
@@ -196,12 +201,25 @@
             transition: all 0.3s ease;
         }
 
+        .confirm-btn {
+            background: linear-gradient(135deg, #4CAF50 0%, #45a049 100%);
+        }
+
+        .confirm-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(76, 175, 80, 0.4);
+        }
+
+        .clear-btn {
+            background: linear-gradient(135deg, #6c757d 0%, #5a6268 100%);
+        }
+
         .clear-btn:hover {
             transform: translateY(-2px);
             box-shadow: 0 5px 15px rgba(108, 117, 125, 0.4);
         }
 
-        .clear-btn:active {
+        .action-btn:active {
             transform: translateY(0);
         }
 
@@ -324,7 +342,10 @@
                 <div class="result-unit" id="resultUnit">100gあたり</div>
             </div>
             
-            <button class="clear-btn" id="clearBtn">クリア</button>
+            <div class="button-group">
+                <button class="action-btn confirm-btn" id="confirmBtn">確定</button>
+                <button class="action-btn clear-btn" id="clearBtn">クリア</button>
+            </div>
             
             <div class="history-section">
                 <h3 class="history-title">直近の計算履歴</h3>
@@ -355,16 +376,6 @@
                 // 入力フィールドのイベント
                 document.getElementById('priceInput').addEventListener('input', () => this.calculate());
                 document.getElementById('volumeInput').addEventListener('input', () => this.calculate());
-                
-                // 入力完了時のイベント（履歴追加用）
-                document.getElementById('priceInput').addEventListener('blur', () => this.onInputComplete());
-                document.getElementById('volumeInput').addEventListener('blur', () => this.onInputComplete());
-                document.getElementById('priceInput').addEventListener('keypress', (e) => {
-                    if (e.key === 'Enter') this.onInputComplete();
-                });
-                document.getElementById('volumeInput').addEventListener('keypress', (e) => {
-                    if (e.key === 'Enter') this.onInputComplete();
-                });
 
                 // 音声入力ボタン
                 document.getElementById('priceVoiceBtn').addEventListener('click', () => this.startVoiceInput('price'));
@@ -374,6 +385,9 @@
                 document.querySelectorAll('.unit-btn').forEach(btn => {
                     btn.addEventListener('click', (e) => this.selectUnit(e.target.dataset.unit, e.target));
                 });
+
+                // 確定ボタン
+                document.getElementById('confirmBtn').addEventListener('click', () => this.confirmCalculation());
 
                 // クリアボタン
                 document.getElementById('clearBtn').addEventListener('click', () => this.clear());
@@ -437,7 +451,6 @@
                     const inputId = this.activeInput === 'price' ? 'priceInput' : 'volumeInput';
                     document.getElementById(inputId).value = value;
                     this.calculate();
-                    this.onInputComplete(); // 音声入力完了時も履歴に追加
                     this.showStatus(`${value}を入力しました`, 'info');
                 } else {
                     this.showStatus('数字が認識できませんでした', 'error');
@@ -475,24 +488,30 @@
                 document.getElementById('resultValue').textContent = resultText;
             }
 
-            onInputComplete() {
+            confirmCalculation() {
                 const price = parseFloat(document.getElementById('priceInput').value) || 0;
                 const volume = parseFloat(document.getElementById('volumeInput').value) || 0;
 
-                if (price > 0 && volume > 0) {
-                    const unitValue = this.getUnitValue(this.currentUnit);
-                    const unitPrice = (price / volume) * unitValue;
-                    
-                    // 同じ計算がすでに履歴にないかチェック
-                    const exists = this.history.some(item => 
-                        item.price === price && 
-                        item.volume === volume && 
-                        item.unit === this.currentUnit
-                    );
-                    
-                    if (!exists && unitPrice > 0) {
-                        this.addToHistory(volume, price, this.currentUnit, unitPrice);
-                    }
+                if (price <= 0 || volume <= 0) {
+                    this.showStatus('価格と容量を入力してください', 'error');
+                    return;
+                }
+
+                const unitValue = this.getUnitValue(this.currentUnit);
+                const unitPrice = (price / volume) * unitValue;
+                
+                // 同じ計算がすでに履歴にないかチェック
+                const exists = this.history.some(item => 
+                    item.price === price && 
+                    item.volume === volume && 
+                    item.unit === this.currentUnit
+                );
+                
+                if (!exists && unitPrice > 0) {
+                    this.addToHistory(volume, price, this.currentUnit, unitPrice);
+                    this.showStatus('履歴に追加しました', 'info');
+                } else if (exists) {
+                    this.showStatus('同じ計算が既に履歴にあります', 'error');
                 }
             }
 


### PR DESCRIPTION
確定ボタンを追加して履歴への追加を制御
- クリアボタンの隣に確定ボタンを追加
- 確定ボタンを押した時のみ履歴に追加
- 自動的な履歴追加を削除（blur, Enter, 音声入力完了時）
- 入力不足や重複時にステータスメッセージ表示
- ボタンのレイアウトとスタイルを調整

🤖 Generated with [Claude Code](https://claude.ai/code)

説明：
  ## 概要
  計算履歴機能に確定ボタンを追加しました。

  ## 変更内容
  - クリアボタンの隣に緑色の「確定」ボタンを追加
  - 確定ボタンを押した時のみ履歴に追加
  - 自動的な履歴追加を削除（意図しない履歴追加を防止）
  - 入力不足や重複時にステータスメッセージ表示
  - 直近3件の計算履歴を「180g 199円 → 100gあたり ¥110.50」形式で表示
